### PR TITLE
Check all version tags prior to rollout

### DIFF
--- a/registry/dockerhub/provider.go
+++ b/registry/dockerhub/provider.go
@@ -84,13 +84,15 @@ func (vp *V2Provider) RegistryFor(imageRepo string) (kcdregistry.Registry, error
 }
 
 // Version implements the Registry interface.
-func (vp *V2Provider) Version(ctx context.Context, tag string) (string, error) {
+func (vp *V2Provider) Versions(ctx context.Context, tag string) ([]string, error) {
+	tags := make([]string, 0, 5)
 	newVersion, err := vp.getDigest(tag)
 	if err != nil {
 		vp.opts.Stats.IncCount("registry.failure", vp.repository)
-		return "", errors.Errorf("No version found for tag %s", tag)
+		return tags, errors.Errorf("No version found for tag %s", tag)
 	}
-	return newVersion, nil
+	tags = append(tags, newVersion)
+	return tags, nil
 }
 
 // Add adds list of tags to the image identified with version

--- a/registry/ecr/provider.go
+++ b/registry/ecr/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -94,7 +95,7 @@ func (ep *Provider) RegistryFor(imageRepo string) (registry.Registry, error) {
 }
 
 // Version implements the Registry interface.
-func (ep *Provider) Version(ctx context.Context, tag string) (string, error) {
+func (ep *Provider) Versions(ctx context.Context, tag string) ([]string, error) {
 	// TODO: parameterize timeout
 	var cancel context.CancelFunc
 	ctx, cancel = context.WithTimeout(ctx, time.Second*15)
@@ -117,26 +118,26 @@ func (ep *Provider) Version(ctx context.Context, tag string) (string, error) {
 	result, err := ep.ecr.DescribeImagesWithContext(ctx, req)
 	if err != nil {
 		glog.Errorf("Failed to get ECR: %v", err)
-		return "", errors.Wrap(err, "failed to get ecr")
+		return nil, errors.Wrap(err, "failed to get ecr")
 	}
 	if len(result.ImageDetails) != 1 {
 		ep.stats.Event(fmt.Sprintf("registry.%s.sync.failure", ep.repoName),
 			fmt.Sprintf("Failed to sync with ECR for tag %s", tag), "", "error",
 			time.Now().UTC(), tag)
-		return "", errors.Errorf("Bad state: More than one image was tagged with %s", tag)
+		return nil, errors.Errorf("Bad state: More than one image was tagged with %s", tag)
 	}
 
 	img := result.ImageDetails[0]
 
-	currentVersion := ep.currentVersion(img)
-	if currentVersion == "" {
+	versions := ep.currentVersions(img)
+	if len(versions) == 0 {
 		ep.stats.IncCount("registry.failure", ep.repoName)
-		return "", errors.Errorf("No version found for tag %s", tag)
+		return nil, errors.Errorf("No version found for tag %s", tag)
 	}
 
-	glog.V(2).Infof("Got currentVersion=%s from ECR", currentVersion)
+	glog.V(2).Infof("Got currentVersions=%s from ECR", strings.Join(versions, ", "))
 
-	return currentVersion, nil
+	return versions, nil
 }
 
 // Add a list of tags to the image identified with version
@@ -253,14 +254,13 @@ func (ep *Provider) Get(version string) ([]string, error) {
 
 }
 
-func (ep *Provider) currentVersion(img *ecr.ImageDetail) string {
-	var tag string
+func (ep *Provider) currentVersions(img *ecr.ImageDetail) []string {
+	tags := make([]string, 0, 5)
 	for _, t := range aws.StringValueSlice(img.ImageTags) {
 
 		if ep.vRegex.MatchString(t) {
-			tag = t
-			break
+			tags = append(tags, t)
 		}
 	}
-	return tag
+	return tags
 }

--- a/registry/export.go
+++ b/registry/export.go
@@ -20,7 +20,11 @@ type Provider interface {
 
 // Registry contains methods for obtaining image information from a registry.
 type Registry interface {
-	Version(ctx context.Context, tag string) (string, error)
+	// Some images may be tagged with multiple versions if, for example, they are built
+	// on each commit and a commit that does not change the resulting image is made
+	// and is tagged. In this case, the syncers check all the tags for the existing
+	// version before determining if a rollout should occur.
+	Versions(ctx context.Context, tag string) ([]string, error)
 }
 
 // Tagger provides capability of adding/removing environment tags on ECR

--- a/resource/sync.go
+++ b/resource/sync.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -98,24 +99,25 @@ func (s *Syncer) initialState() state.StateFunc {
 		// refresh kcd resource state
 		s.kcd = kcd
 
-		version, err := s.registry.Version(ctx, s.kcd.Spec.Tag)
+		versions, err := s.registry.Versions(ctx, s.kcd.Spec.Tag)
 		if err != nil {
 			glog.Errorf("Syncer failed to get version from registry, kcd=%s, tag=%s: %v", s.kcd.Name, kcd.Spec.Tag, err)
-			s.options.Recorder.Event(events.Warning, "KCDSyncFailed", "Failed to get version from registry")
-			return state.Error(errors.Wrap(err, "failed to get version from registry"))
+			s.options.Recorder.Event(events.Warning, "KCDSyncFailed", "Failed to get versions from registry")
+			return state.Error(errors.Wrap(err, "failed to get versions from registry"))
 		}
 
+		version := versions[0]
 		if glog.V(4) {
-			glog.V(4).Infof("Got registry version for kcd=%s, tag=%s, version=%v", s.kcd.Name, kcd.Spec.Tag, version)
+			glog.V(4).Infof("Got registry versions for kcd=%s, tag=%s, versions=%v, rolloutVersion=%s", s.kcd.Name, kcd.Spec.Tag, strings.Join(versions, ", "), version)
 		}
 
-		deployer, err := deploy.New(s.workloadProvider, s.registryProvider, s.kcd, version)
+		deployer, err := deploy.New(s.workloadProvider, s.registryProvider, s.kcd, versions[0])
 		if err != nil {
 			glog.Errorf("Failed to create deployer for kcd=%s: %v", s.kcd.Name, err)
 			return state.Error(errors.Wrap(err, "failed to create deployer"))
 		}
 
-		process, err := s.shouldProcess(deployer, s.kcd, version)
+		process, err := s.shouldProcess(deployer, s.kcd, versions)
 		if err != nil {
 			glog.Errorf("Failed to determine whether workloads should be processed for kcd=%s: %v", s.kcd.Name, err)
 			return state.Error(errors.Wrapf(err, "failed to determine whether workloads should be processed for kcd=%s", s.kcd.Name))
@@ -141,9 +143,16 @@ func (s *Syncer) initialState() state.StateFunc {
 
 // shouldProcess returns whether a rollout should be performed on the workloads defined
 // by the KCD resource.
-func (s *Syncer) shouldProcess(deployer deploy.Deployer, kcd *kcd1.KCD, version string) (bool, error) {
+func (s *Syncer) shouldProcess(deployer deploy.Deployer, kcd *kcd1.KCD, versions []string) (bool, error) {
+	var containsCurrentVersion bool
+	for _, version := range versions {
+		if version == kcd.Status.CurrVersion {
+			containsCurrentVersion = true
+			break
+		}
+	}
 	// if version changes then always process
-	if version != kcd.Status.CurrVersion {
+	if !containsCurrentVersion {
 		return true, nil
 	}
 

--- a/verify/image.go
+++ b/verify/image.go
@@ -121,11 +121,12 @@ func (iv *ImageVerifier) getImage(ctx context.Context, spec kcd1.VerifySpec) (st
 		return "", errors.Wrapf(err, "failed to get registry for %s", spec.Image)
 	}
 
-	version, err := registry.Version(ctx, spec.Tag)
+	versions, err := registry.Versions(ctx, spec.Tag)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get version from registry for %+v", spec)
 	}
 
+	version := versions[0]
 	parts := strings.SplitN(spec.Image, ":", 2)
 	return fmt.Sprintf("%s:%s", parts[0], version), nil
 }


### PR DESCRIPTION
Avoid the case where a rollout is preformed when the same image
has multiple version tags.