### PR TITLE
Workaround cases if manually check manifest tag, no version changed, …

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -99,7 +99,7 @@ func CheckPods(cs kubernetes.Interface, namespace string, target RolloutTarget, 
 		//	glog.V(2).Infof("Still waiting for rollout: pod %s phase is %v", pod.Name, pod.Status.Phase)
 		//	return false, nil
 		//}
-		glog.V(4).Infof("Check pod spev version %v, $v", pod.Name, pod.Namespace)
+		glog.V(4).Infof("Check pod spec version %v, $v", pod.Name, pod.Namespace)
 
 		ok, err := workload.CheckPodSpecVersion(pod.Spec, kcd, version)
 		if err != nil {

--- a/gok8s/workload/workload.go
+++ b/gok8s/workload/workload.go
@@ -98,16 +98,15 @@ func CheckPodSpecVersion(podSpec corev1.PodSpec, kcd *kcdv1.KCD, taggedVersion s
 			configVersion := parts[1]
 			if !versionRegex.MatchString(configVersion) {
 				glog.V(4).Infof("Current image tag from manifest not SHA: %v, %v", configVersion, c.Name)
-				return false, nil
+				return true, nil
 			}
 
 			glog.V(4).Infof("Current image tag from manifest: %v, %v", configVersion, c.Name)
 			if configVersion != taggedVersion {
 				glog.V(4).Infof("Current image tag from manifest not equal " +
 					" to tagged version from ECR: %v, %v", configVersion, taggedVersion)
-				return true, nil
+				return false, nil
 			}
-			return false, nil
 		}
 	}
 

--- a/gok8s/workload/workload.go
+++ b/gok8s/workload/workload.go
@@ -78,7 +78,7 @@ type TemplateWorkload interface {
 // Return false if it is not a image SHA
 // Returns an error if no containers in the pod spec match the container name
 // defined by the KCD resource.
-func CheckPodSpecVersion(podSpec corev1.PodSpec, kcd *kcdv1.KCD, taggedVersion string) (bool, error) {
+func CheckPodSpecVersion(podSpec corev1.PodSpec, kcd *kcdv1.KCD, versions ...string) (bool, error) {
 	match := false
 	glog.V(4).Infof("podSpec: %v kcd: %v", podSpec, kcd)
 	versionRegex, _ := regexp.Compile(`[0-9a-f]{5,40}`)
@@ -94,18 +94,37 @@ func CheckPodSpecVersion(podSpec corev1.PodSpec, kcd *kcdv1.KCD, taggedVersion s
 				return false, errors.Errorf("Repository mismatch for container %s: %s and requested %s don't match",
 					c.Name, parts[0], kcd.Spec.ImageRepo)
 			}
+			// Test for checking if tag not SHA (manifest always SHA, means something manual apply), doing nothing on deployment
+			if kcd.Namespace == "hello-service" {
+				configVersion := parts[1]
+				if !versionRegex.MatchString(configVersion) {
+					glog.V(4).Infof("Current image tag from manifest not SHA: %v, %v", configVersion, c.Name)
+					return true, nil
+				}
 
-			configVersion := parts[1]
-			if !versionRegex.MatchString(configVersion) {
-				glog.V(4).Infof("Current image tag from manifest not SHA: %v, %v", configVersion, c.Name)
-				return true, nil
-			}
+				glog.V(4).Infof("Current image tag from manifest: %v, %v", configVersion, c.Name)
 
-			glog.V(4).Infof("Current image tag from manifest: %v, %v", configVersion, c.Name)
-			if configVersion != taggedVersion {
-				glog.V(4).Infof("Current image tag from manifest not equal " +
-					" to tagged version from ECR: %v, %v", configVersion, taggedVersion)
-				return false, nil
+				for _, version := range versions {
+					if configVersion != version {
+						glog.V(4).Infof("Current image tag from manifest not equal " +
+							" to tagged version from ECR: %v, %v", configVersion, version)
+						return false, nil
+					}
+				}
+			} else {
+				found := false
+				cver := parts[1]
+				glog.V(4).Infof("Current image tag from manifest: %v, %v", cver, c.Name)
+				for _, version := range versions {
+					if cver == version {
+						found = true
+						break
+					}
+				}
+				if !found {
+					glog.V(4).Info("Version not found")
+					return false, nil
+				}
 			}
 		}
 	}

--- a/gok8s/workload/workload.go
+++ b/gok8s/workload/workload.go
@@ -75,7 +75,7 @@ type TemplateWorkload interface {
 // names that match the kcd spec have the given version.
 // Returns false if at least one container's version does not match at least one
 // specified version.
-// Return false if checking it is not a image SHA
+// Return false if it is not a image SHA
 // Returns an error if no containers in the pod spec match the container name
 // defined by the KCD resource.
 func CheckPodSpecVersion(podSpec corev1.PodSpec, kcd *kcdv1.KCD, taggedVersion string) (bool, error) {

--- a/resource/sync.go
+++ b/resource/sync.go
@@ -145,7 +145,7 @@ func (s *Syncer) initialState() state.StateFunc {
 // shouldProcess returns whether a rollout should be performed on the workloads defined
 // by the KCD resource.
 func (s *Syncer) shouldProcess(deployer deploy.Deployer, kcd *kcd1.KCD, versions []string) (bool, error) {
-	var containsCurrentVersion bool
+	containsCurrentVersion := false
 	for _, version := range versions {
 		if version == kcd.Status.CurrVersion {
 			containsCurrentVersion = true


### PR DESCRIPTION
We were checking the manifest tag version. But it is manually changed from SHA to tags, we won't start a new deployment