### PR TITLE
Make the ECR version tagging regular expression exactly match the image tag instead of containing

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -2,12 +2,12 @@ package deploy
 
 import (
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	kcd1 "github.com/wish/kcd/gok8s/apis/custom/v1"
 	"github.com/wish/kcd/gok8s/workload"
 	k8s "github.com/wish/kcd/gok8s/workload"
 	"github.com/wish/kcd/registry"
 	"github.com/wish/kcd/state"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -99,7 +99,7 @@ func CheckPods(cs kubernetes.Interface, namespace string, target RolloutTarget, 
 		//	glog.V(2).Infof("Still waiting for rollout: pod %s phase is %v", pod.Name, pod.Status.Phase)
 		//	return false, nil
 		//}
-		glog.V(4).Infof("Check pod spec version %v, $v", pod.Name, pod.Namespace)
+		glog.V(4).Infof("Check pod spec version %v, %v", pod.Name, pod.Namespace)
 
 		ok, err := workload.CheckPodSpecVersion(pod.Spec, kcd, version)
 		if err != nil {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -2,12 +2,12 @@ package deploy
 
 import (
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	kcd1 "github.com/wish/kcd/gok8s/apis/custom/v1"
 	"github.com/wish/kcd/gok8s/workload"
 	k8s "github.com/wish/kcd/gok8s/workload"
 	"github.com/wish/kcd/registry"
 	"github.com/wish/kcd/state"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/events/patch.go
+++ b/events/patch.go
@@ -22,8 +22,7 @@ const (
 	KcdAppName = "kcdapp"
 
 	ContainerPatchPath = "/spec/template/spec/containers"
-
-	VersionRegex = "[0-9a-f]{5,40}"
+	
 )
 
 // objectWithMeta allows us to unmarshal just the ObjectMeta of a k8s object
@@ -44,7 +43,7 @@ type patchOperation struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
-var versionRegex, _ = regexp.Compile(`[0-9a-f]{5,40}`)
+var versionRegex, _ = regexp.Compile(ecr.VersionRegex)
 
 // Get the container image string value addressed by nameParts
 func (r Record) Get(nameParts []string, cName string) (string, string, bool) {
@@ -261,7 +260,7 @@ func patchForContainer(cName string, current, replacement Record, stats stats.St
 		Path:  pathToPatch,
 	}
 
-	p, e := ecr.NewECR(imageRepoFlux, VersionRegex, stats)
+	p, e := ecr.NewECR(imageRepoFlux, ecr.VersionRegex, stats)
 	if e != nil {
 		glog.Errorf("Unable to create ECR for iamge repo %v at version: %v", imageRepo, curTag)
 		return nil, false

--- a/k8s/crd.yaml
+++ b/k8s/crd.yaml
@@ -31,7 +31,7 @@ spec:
             versionSyntax:
               type: string
               ## default to regex for sha
-              # default: '[0-9a-f]{5,40}'
+              # default: '^[0-9a-f]{5,40}$'
             imageRepo:
               type: string
               pattern: '^[^:]*$'

--- a/k8s/helm/kcd/templates/crd.yaml
+++ b/k8s/helm/kcd/templates/crd.yaml
@@ -31,7 +31,7 @@ spec:
             versionSyntax:
               type: string
               ## default to regex for sha
-              # default: '[0-9a-f]{5,40}'
+              # default: '^[0-9a-f]{5,40}$'
             imageRepo:
               type: string
               pattern: '^[^:]*$'

--- a/k8s/ktmpl/kcd.yaml
+++ b/k8s/ktmpl/kcd.yaml
@@ -40,7 +40,7 @@ objects:
                 versionSyntax:
                   type: string
                   ## default to regex for sha
-                  # default: '[0-9a-f]{5,40}'
+                  # default: '^[0-9a-f]{5,40}$'
                 imageRepo:
                   type: string
                   pattern: '^[^:]*$'

--- a/k8s/kubectl/kcd.yaml
+++ b/k8s/kubectl/kcd.yaml
@@ -31,7 +31,7 @@ spec:
             versionSyntax:
               type: string
               ## default to regex for sha
-              # default: '[0-9a-f]{5,40}'
+              # default: '^[0-9a-f]{5,40}$'
             imageRepo:
               type: string
               pattern: '^[^:]*$'

--- a/registry/ecr/provider.go
+++ b/registry/ecr/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+const VersionRegex = `^[0-9a-f]{5,40}$`
 var ecrRule, _ = regexp.Compile("([0-9]*).dkr.ecr.([a-z0-9-]*).amazonaws.com/([a-zA-Z0-9/\\_-]*)")
 
 // nameAccountRegionFromARN returns the name of the repo, the AWS Account ID and region

--- a/registry/ecr/provider_test.go
+++ b/registry/ecr/provider_test.go
@@ -1,0 +1,40 @@
+package ecr
+
+import (
+	"testing"
+)
+
+func TestVersionRegex(t *testing.T) {
+	registryProvider, err := NewECR("951896542015.dkr.ecr.us-west-1.amazonaws.com/contextlogic/robbie", VersionRegex, nil)
+	if err != nil {
+		t.Errorf("err should not be nil to initialize the ECR Provider for unit test")
+	}
+	if !registryProvider.vRegex.MatchString("d21e94a3") {
+		t.Errorf("d21e94a3 shoud be matched")
+	}
+	if !registryProvider.vRegex.MatchString("10293f4") {
+		t.Errorf("10293f4 shoud be matched")
+	}
+	if !registryProvider.vRegex.MatchString("10293f4149c0baf908e1e5608ecf228b7ff2e165") {
+		t.Errorf("10293f4149c0baf908e1e5608ecf228b7ff2e165 shoud be matched")
+	}
+	if registryProvider.vRegex.MatchString("master1671212064") {
+		t.Errorf("master1671212064 shoud not be matched")
+	}
+	if registryProvider.vRegex.MatchString("my_awesome_branch") {
+		t.Errorf("my_awesome_branch shoud not be matched")
+	}
+	if registryProvider.vRegex.MatchString("master") {
+		t.Errorf("master shoud not be matched")
+	}
+	if registryProvider.vRegex.MatchString("prod") {
+		t.Errorf("prod shoud not be matched")
+	}
+	if registryProvider.vRegex.MatchString("staging") {
+		t.Errorf("staging shoud not be matched")
+	}
+	if registryProvider.vRegex.MatchString("dev") {
+		t.Errorf("dev shoud not be matched")
+	}
+
+}

--- a/sync.go
+++ b/sync.go
@@ -175,7 +175,7 @@ func newKCDSyncCommand(root *regRoot) *cobra.Command {
 		// TODO: this needs a better strategy but hacking it for now
 		//
 		if kcd.Spec.VersionSyntax == "" {
-			kcd.Spec.VersionSyntax = "[0-9a-f]{5,40}"
+			kcd.Spec.VersionSyntax = ecr.VersionRegex
 		}
 		var registryProvider registry.Provider
 		switch registry.ProviderByRepo(kcd.Spec.ImageRepo) {
@@ -262,7 +262,7 @@ func newTagsCommand(root *regRoot) *cobra.Command {
 	var crProvider registry.Tagger
 	var params regTagParams
 	cmd.PersistentFlags().StringSliceVar(&params.tags, "tags", nil, "list of tags that needs to be added or removed")
-	cmd.PersistentFlags().StringVar(&params.verPat, "version-pattern", "[0-9a-f]{5,40}", "Regex pattern for container version")
+	cmd.PersistentFlags().StringVar(&params.verPat, "version-pattern", ecr.VersionRegex, "Regex pattern for container version")
 	cmd.PersistentFlags().StringVar(&params.version, "version", "", "sha/version tag of registry image that is being tagged")
 	cmd.PersistentFlags().StringVar(&params.username, "username", "", "username of dockerhub registry")
 	cmd.PersistentFlags().StringVar(&params.pwd, "passsword", "", "password of user of dockerhub registry")


### PR DESCRIPTION
## Problem: 
Currently, the tag of 8 char length short commit SHA on git is expected to be matched as a potential target associated with the deployment environment. However, the current Regex `[0-9a-f]{5,40}` matches any qualified preceding tokens, thus having the logic of "match any". This would cause a problem with unexpected matches, e.g., when a branch name master and timestamp ensemble a tag `master_1671212099` for example, this will be also matched with the regex, thus violating Wish internal naming convention. 

So this PR is to make the regex exactly match the tag, instead of "match any".

## Testing 
Add unit test registry/ecr/provider_test.go

Local Docker build
```
docker build -t nearmap/kcd .

xxxx
xxxx

 => exporting to image                                                                                                                                                                                                                                                                                0.2s
 => => exporting layers                                                                                                                                                                                                                                                                               0.2s
 => => writing image sha256:5757f4b0f53810a8ee441893f3483a62ebfc376d90d60fd30f269a06e119e74e                                                                                                                                                                                                          0.0s
 => => naming to docker.io/nearmap/kcd  
```
